### PR TITLE
Use docker credentials from a secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,20 @@ Using OCI registry as an evidence store allows you to upload and verify evidence
 Related configmap flags:
 >* `config.attest.cocosign.storer.OCI.enable` - Enable OCI store.
 >* `config.attest.cocosign.storer.OCI.repo` - Evidence store location.
-<!-- * `imagePullSecrets` - Secret name for private registry. -->
+
+## Private registries
+To verify images from registries that require authentication, create a Kubernetes image pull secret named `gatekeeper-valint-pull-secret`.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gatekeeper-valint-pull-secret
+  namespace: gatekeeper-valint
+data:
+  .dockerconfigjson: ewoJImF1...g==
+type: kubernetes.io/dockerconfigjson
+```
 
 ### Dockerhub limitation
 Dockerhub does not support the subpath format, `oci-repo` should be set to your Dockerhub Username.

--- a/charts/gatekeeper-valint/templates/deployment.yaml
+++ b/charts/gatekeeper-valint/templates/deployment.yaml
@@ -26,6 +26,8 @@ spec:
           value: {{ quote .Values.gatekeeperValint.sigstoreNoCache }}
         - name: DEBUG
           value: {{ quote .Values.gatekeeperValint.debug }}
+        - name: DOCKER_CONFIG
+          value: "/docker"
         - name: VALINT_SCRIBE_AUTH_CLIENT_ID
           valueFrom:
             secretKeyRef:
@@ -59,6 +61,9 @@ spec:
           protocol: TCP
         resources: {}
         volumeMounts:
+        - mountPath: /docker/
+          name: valint-pull-secret
+          readOnly: true
         - mountPath: /valint
           name: valint-config
           readOnly: true
@@ -73,6 +78,13 @@ spec:
       - configMap:
           name: gatekeeper-valint-config
         name: valint-config
+      - name: valint-pull-secret
+        secret:
+          secretName: gatekeeper-valint-pull-secret
+          optional: true
+          items:
+            - key: .dockerconfigjson
+              path: config.json
       - name: valint-certs
         secret:
           secretName: gatekeeper-valint-certs


### PR DESCRIPTION
It seem that specifying DOCKER_CONFIG and pointing to the mounted secret automagically make libraries work since default auth.Keychain utilises this env variable to search for credentials file.